### PR TITLE
Fix tick query fired when clicking liquidity in pool page

### DIFF
--- a/src/data/pools/tickData.ts
+++ b/src/data/pools/tickData.ts
@@ -131,7 +131,7 @@ export interface PoolTickData {
 }
 
 const poolQuery = gql`
-  query pool($poolAddress: String!) {
+  query pool($poolAddress: ID!) {
     pool(id: $poolAddress) {
       tick
       token0 {

--- a/src/data/search/index.ts
+++ b/src/data/search/index.ts
@@ -32,7 +32,7 @@ export const TOKEN_SEARCH = gql`
 `
 
 export const POOL_SEARCH = gql`
-  query pools($tokens: [Bytes]!, $id: String) {
+  query pools($tokens: [String]!, $id: ID) {
     as0: pools(where: { token0_in: $tokens }) {
       id
       feeTier


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/261